### PR TITLE
Native lua support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint: build
 	moonc -l lapis
 
 local: build
-	luarocks make --local lapis-annotate-dev-1.rockspec
+	luarocks --lua-version 5.1 make --local lapis-annotate-dev-1.rockspec
 
 build:
 	moonc lapis

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ After:
 
 
 ```lua
+local Model = require("lapis.db.model").Model
+
 -- Generated schema dump: (do not edit)
 --
 -- CREATE TABLE user_ip_addresses (
@@ -82,20 +84,23 @@ After:
 -- CREATE INDEX user_ip_addresses_ip_idx ON user_ip_addresses USING btree (ip);
 -- End user_ip_addresses schema
 --
-
-local Model = require("lapis.db.model").Model
-
-local UserIpAddresses = Model:extend('', {
+local UserIpAddresses = Model:extend('user_ip_addresses ', {
   timestamp = true,
   primary_key = {"user_id", "ip"}
 })
+
+return UserIpAddress
 ```
 ## Notes
 
 Only supports PostgreSQL at the moment.
 
 When using MoonScript, annotations are placed before the `class` line.
-When using Lua, annotations are placed at the top of the file.
+
+### Lua Mode
+You must return your model instance from the Lua file. `lapis-annotate` expects
+a camelcase variable name for each model, but if not found it will place annotations
+at the top of the lua file.
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ luarocks install lapis-annotate
 $ lapis annotate models/my_model.moon
 ```
 
-Before: 
+### Moonscript
+Before:
 
 ```moon
 import Model from require "lapis.db.model"
@@ -43,6 +44,7 @@ import Model from require "lapis.db.model"
 -- ALTER TABLE ONLY user_ip_addresses
 --   ADD CONSTRAINT user_ip_addresses_pkey PRIMARY KEY (user_id, ip);
 -- CREATE INDEX user_ip_addresses_ip_idx ON user_ip_addresses USING btree (ip);
+-- End user_ip_addresses schema
 --
 class UserIpAddresses extends Model
   @timestamp: true
@@ -51,9 +53,49 @@ class UserIpAddresses extends Model
 
 ```
 
+### Lua
+Before:
+
+```Lua
+local Model = require("lapis.db.model").Model
+
+local UserIpAddresses = Model:extend('user_ip_addresses', {
+  timestamp = true,
+  primary_key = {"user_id", "ip"}
+})
+```
+
+After:
+
+
+```lua
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE user_ip_addresses (
+--   user_id integer NOT NULL,
+--   ip character varying(255) NOT NULL,
+--   created_at timestamp without time zone NOT NULL,
+--   updated_at timestamp without time zone NOT NULL
+-- );
+-- ALTER TABLE ONLY user_ip_addresses
+--   ADD CONSTRAINT user_ip_addresses_pkey PRIMARY KEY (user_id, ip);
+-- CREATE INDEX user_ip_addresses_ip_idx ON user_ip_addresses USING btree (ip);
+-- End user_ip_addresses schema
+--
+
+local Model = require("lapis.db.model").Model
+
+local UserIpAddresses = Model:extend('', {
+  timestamp = true,
+  primary_key = {"user_id", "ip"}
+})
+```
 ## Notes
 
-Only supports MoonScript and PostgreSQL at the moment
+Only supports PostgreSQL at the moment.
+
+When using MoonScript, annotations are placed before the `class` line.
+When using Lua, annotations are placed at the top of the file.
 
 ## Changes
 

--- a/lapis/cmd/actions/annotate.lua
+++ b/lapis/cmd/actions/annotate.lua
@@ -1,5 +1,7 @@
 local default_environment
 default_environment = require("lapis.cmd.util").default_environment
+local camelize
+camelize = require("lapis.util").camelize
 local shell_escape
 shell_escape = function(str)
   return "'" .. tostring(str:gsub("'", "''")) .. "'"
@@ -135,11 +137,11 @@ annotate_model = function(config, fname)
     model = assert(loadfile(fname)())
   end
   if fname:match(".lua$") then
-    start_of_class = ""
+    start_of_class = source:match("local " .. tostring(camelize(model:table_name()))) or ""
   end
   local header = extract_header(config, model)
   local table_name = model:table_name()
-  local annotation_content = "%-%- Generated .*\n%-%- End " .. tostring(table_name) .. " schema\n%-%-\n" .. tostring(start_of_class)
+  local annotation_content = "%-%- Generated .-\n%-%- End " .. tostring(table_name) .. " schema\n%-%-\n" .. tostring(start_of_class)
   local source_with_header
   if source:match(annotation_content) then
     source_with_header = source:gsub(annotation_content, tostring(header) .. "\n" .. tostring(start_of_class), 1)

--- a/lapis/cmd/actions/annotate.lua
+++ b/lapis/cmd/actions/annotate.lua
@@ -137,7 +137,7 @@ annotate_model = function(config, fname)
     model = assert(loadfile(fname)())
   end
   if fname:match(".lua$") then
-    start_of_class = source:match("local " .. tostring(camelize(model:table_name()))) or ""
+    start_of_class = source:match("local " .. tostring(camelize(model:table_name())) .. " ") or ""
   end
   local header = extract_header(config, model)
   local table_name = model:table_name()

--- a/lapis/cmd/actions/annotate.moon
+++ b/lapis/cmd/actions/annotate.moon
@@ -1,4 +1,5 @@
 import default_environment from require "lapis.cmd.util"
+import camelize from require "lapis.util"
 
 shell_escape = (str) ->
   "'#{str\gsub "'", "''"}'"
@@ -88,12 +89,12 @@ annotate_model = (config, fname) ->
     assert loadfile(fname)!
 
   if fname\match ".lua$"
-    start_of_class = ""
+    start_of_class = source\match("local #{camelize model\table_name!}") or ""
 
   header = extract_header config, model
 
   table_name = model\table_name!
-  annotation_content = "%-%- Generated .*\n%-%- End #{table_name} schema\n%-%-\n#{start_of_class}"
+  annotation_content = "%-%- Generated .-\n%-%- End #{table_name} schema\n%-%-\n#{start_of_class}"
   source_with_header = if source\match annotation_content
     source\gsub annotation_content, "#{header}\n#{start_of_class}", 1
   else

--- a/lapis/cmd/actions/annotate.moon
+++ b/lapis/cmd/actions/annotate.moon
@@ -89,7 +89,7 @@ annotate_model = (config, fname) ->
     assert loadfile(fname)!
 
   if fname\match ".lua$"
-    start_of_class = source\match("local #{camelize model\table_name!}") or ""
+    start_of_class = source\match("local #{camelize model\table_name!} ") or ""
 
   header = extract_header config, model
 


### PR DESCRIPTION
This PR allows `lapis annotate model.lua` to work successfully.

It does this by accepting two compromises:

* Annotations now end with a line `-- End #{table_name} schema}`, in both Lua and MoonScript files
* In Lua mode, annotations are at the very top of the file, OR right before the line `local TableName...`

It seemed useful to have a default mode of the top of the file since the `local TableName` style may not be quite as common?