### PR TITLE
Add support for annotating lua model files

### DIFF
--- a/lapis/cmd/actions/annotate.lua
+++ b/lapis/cmd/actions/annotate.lua
@@ -23,7 +23,7 @@ build_command = function(cmd, config)
   do
     local password = config.postgres.password
     if password then
-      table.insert(1, command, "PGPASSWORD=" .. tostring(shell_escape(password)))
+      table.insert(command, 1, "PGPASSWORD=" .. tostring(shell_escape(password)))
     end
   end
   do
@@ -229,8 +229,16 @@ annotate_model = function(config, fname, options)
   end
   local header = table.concat(header_lines, "\n") .. "\n"
   local updated_source = replace_header(source, header)
-  if not (updated_source) then
-    updated_source = source:gsub("class ", tostring(header) .. "class ", 1)
+  if fname:match(".lua$") and not updated_source then
+    local lua_declaration = "local %w+ = Model:extend"
+    if not source:match(lua_declaration) then
+      print("\tLine matching '" .. tostring(lua_declaration) .. "' not found")
+    end
+    updated_source = source:gsub(lua_declaration, tostring(header) .. "%1 ", 1)
+  else
+    if not updated_source then
+      updated_source = source:gsub("class ", tostring(header) .. "class ", 1)
+    end
   end
   local source_out = assert(io.open(fname, "w"))
   source_out:write(updated_source)

--- a/lapis/cmd/actions/annotate.moon
+++ b/lapis/cmd/actions/annotate.moon
@@ -17,7 +17,7 @@ build_command = (cmd, config) ->
   command = { cmd }
 
   if password = config.postgres.password
-    table.insert 1, command, "PGPASSWORD=#{shell_escape password}"
+    table.insert command, 1, "PGPASSWORD=#{shell_escape password}"
 
   if host = config.postgres.host
     table.insert command, "-h #{shell_escape host}"
@@ -149,8 +149,12 @@ annotate_model = (config, fname, options={}) ->
 
   updated_source = replace_header source, header
 
-  -- TODO: this is kinda sloppy and only works with MoonScript
-  unless updated_source
+  -- TODO: this is kinda sloppy
+  if fname\match(".lua$") and not updated_source
+    lua_declaration = "local %w+ = Model:extend"
+    print "\tLine matching '#{lua_declaration}' not found" if not source\match lua_declaration
+    updated_source = source\gsub lua_declaration, "#{header}%1 ", 1
+  else if not updated_source
     updated_source = source\gsub "class ", "#{header}class ", 1
 
   source_out = assert io.open fname, "w"


### PR DESCRIPTION
Hi @leafo, 

Is there interest in supporting lapis projects which do not use Moonscript? 
I have re-written this since the last PR, and thanks to the refactoring, it's now quite simple. :) 

I was able to successfully use this for the following PR in our lapis app.
https://github.com/snap-cloud/snapCloud/pull/355/files#diff-536051a826b3ce1fdc058ac7368426038abf2f72a096067103c1ed7e82665ee0

I opted to be a little flexible with the declaration syntax or the model class `local %w+ = Model:extend` to insert the annotations. (I was going to strictly follow camelCase, but ran into one case where our variable name didn't exactly match the `camelize` function.) Of course, the does require you use local variables and not rename `Model`, but I think those are acceptable compromises. 

I will re-add the docs if you think this is helpful. 

Thanks!